### PR TITLE
feat: props 로 각 step에 data 전달해서 페이지 이동 시에도 데이터 초기화 방지 - UX 개선

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -92,7 +92,7 @@ body {
 }
 
 .common-btn {
-  @apply bg-primary hover:bg-hover text-white font-bold rounded-md text-base inline-flex justify-center items-center transition-all;
+  @apply bg-primary hover:bg-hover text-white font-bold rounded-md text-base transition-all;
 }
 
 .common-btn:disabled {

--- a/src/components/todaysmeal/MealPlanner.tsx
+++ b/src/components/todaysmeal/MealPlanner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import useFunnel from '@/components/todaysmeal/useFunnel';
+import useFunnel from '@/hooks/useFunnel';
 import ProgressIndicator from '@/components/todaysmeal/progress/ProgressIndicator';
 import Step0Start from '@/components/todaysmeal/steps/Step0Start';
 import Step1Goal from '@/components/todaysmeal/steps/Step1Goal';
@@ -23,12 +23,13 @@ interface MealPlanData {
 
 const MealPlanner = () => {
   const { Funnel, Step, next, prev, currentStep } = useFunnel('시작');
-  const [mealPlanData, setMealPlanData] = useState<MealPlanData>({});
+  const [mealPlanData, setMealPlanData] = useState<MealPlanData>({}); //받은 데이터 관리용
 
-  const steps = ['시작', '목표', '끼니', 'BMI', '성별과나이', '활동량', '요약'];
+  const steps = ['시작', '목표', '끼니', '키와체중', '성별과나이', '활동량', '추천식단'];
 
   const handleNext = (data: Partial<MealPlanData>, nextStep: string) => {
     setMealPlanData((prev) => ({ ...prev, ...data }));
+    console.log(mealPlanData);
     next(nextStep);
   };
 
@@ -38,44 +39,64 @@ const MealPlanner = () => {
 
   return (
     <div className="flex justify-center items-center flex-col bg-white shadow-lg rounded-lg max-w-[1200px] mx-auto border-primary border-2 h-auto p-6">
-      {currentStep !== '시작' && <ProgressIndicator steps={steps} currentStep={steps.indexOf(currentStep)} />}
+      {currentStep !== '시작' && <ProgressIndicator steps={steps} currentStepIndex={steps.indexOf(currentStep)} />}
 
       <Funnel>
         {/* Step 0: 시작 */}
         <Step name="시작">
           <Step0Start onNext={() => next('목표')} />
+          {/* 받는 데이터가 없음 */}
         </Step>
 
         {/* Step 1: 목표 */}
         <Step name="목표">
-          <Step1Goal onNext={(goal) => handleNext({ goal }, '끼니')} onPrev={() => handlePrev('시작')} />
+          <Step1Goal
+            data={mealPlanData.goal}
+            onNext={(goal) => handleNext({ goal }, '끼니')}
+            onPrev={() => handlePrev('시작')}
+          />
         </Step>
 
         {/* Step 2: 끼니 */}
         <Step name="끼니">
-          <Step2Meal onNext={(meals) => handleNext({ meals }, 'BMI')} onPrev={() => handlePrev('목표')} />
+          <Step2Meal
+            data={mealPlanData.meals}
+            onNext={(meals) => handleNext({ meals }, '키와체중')}
+            onPrev={() => handlePrev('목표')}
+          />
         </Step>
 
-        {/* Step 3: BMI */}
-        <Step name="BMI">
-          <Step3HeightWeight onNext={(data) => handleNext(data, '성별과나이')} onPrev={() => handlePrev('끼니')} />
+        {/* Step 3: 키와체중 */}
+        <Step name="키와체중">
+          <Step3HeightWeight
+            heightData={mealPlanData.height}
+            weightData={mealPlanData.weight}
+            onNext={(data) => handleNext(data, '성별과나이')}
+            onPrev={() => handlePrev('끼니')}
+          />
         </Step>
 
         {/* Step 4: 성별과나이 */}
         <Step name="성별과나이">
-          <Step4GenderAge onNext={(data) => handleNext(data, '활동량')} onPrev={() => handlePrev('BMI')} />
+          <Step4GenderAge
+            genderData={mealPlanData.gender}
+            ageData={mealPlanData.age}
+            onNext={(data) => handleNext(data, '활동량')}
+            onPrev={() => handlePrev('키와체중')}
+          />
         </Step>
 
         {/* Step 5: 활동량 */}
         <Step name="활동량">
           <Step5Activity
-            onNext={(activity) => handleNext({ activity }, '요약')}
+            activityData={mealPlanData.activity}
+            onNext={(activity) => handleNext({ activity }, '추천식단')}
             onPrev={() => handlePrev('성별과나이')}
           />
         </Step>
 
-        {/* Step 6: 요약 */}
-        <Step name="요약">
+        {/* Step 6: 추천식단 */}
+        <Step name="추천식단">
           <Step6Recommendation data={mealPlanData} onPrev={() => handlePrev('활동량')} />
         </Step>
       </Funnel>

--- a/src/components/todaysmeal/buttons/NextButton.tsx
+++ b/src/components/todaysmeal/buttons/NextButton.tsx
@@ -9,7 +9,11 @@ interface NextButtonProps {
 
 const NextButton = ({ onClick, disabled = false }: NextButtonProps) => {
   return (
-    <button className="common-btn w-1/3 py-3 p-4 space-x-2" onClick={onClick} disabled={disabled}>
+    <button
+      className="common-btn inline-flex justify-center items-center w-1/3 py-3 p-4 space-x-2"
+      onClick={onClick}
+      disabled={disabled}
+    >
       <span className="hidden sm:inline">다음으로</span>
       <IoIosArrowForward className="text-lg" />
     </button>

--- a/src/components/todaysmeal/progress/ProgressIndicator.tsx
+++ b/src/components/todaysmeal/progress/ProgressIndicator.tsx
@@ -4,21 +4,21 @@ import React from 'react';
 
 interface ProgressIndicatorProps {
   steps: string[];
-  currentStep: number;
+  currentStepIndex: number;
 }
 
-const ProgressIndicator = ({ steps, currentStep }: ProgressIndicatorProps) => {
+const ProgressIndicator = ({ steps, currentStepIndex }: ProgressIndicatorProps) => {
   return (
     <div className="w-full flex flex-col items-center mt-6">
       <div className="flex w-full max-w-4xl justify-between items-center">
         {steps.map((step, index) => (
           <div key={step} className={`flex items-center ${index === steps.length - 1 ? '' : 'flex-1'}`}>
-            {/* 마지막은 사이 선 넣을 공간 없애기기*/}
+            {/* 마지막은 사이 선 넣을 공간 없애기*/}
             <div
               className={`w-10 h-10 flex justify-center items-center rounded-full font-bold text-sm sm:text-base md:text-lg lg:text-xl ${
-                index < currentStep
+                index < currentStepIndex
                   ? 'bg-hover text-white'
-                  : index === currentStep
+                  : index === currentStepIndex
                   ? 'bg-primary text-white'
                   : 'bg-gray-200 text-gray-500'
               }`}
@@ -29,7 +29,7 @@ const ProgressIndicator = ({ steps, currentStep }: ProgressIndicatorProps) => {
             </div>
 
             {index < steps.length - 1 && (
-              <div className={`flex-1 h-[2px] mx-2 ${index < currentStep ? 'bg-primary' : 'bg-gray-300'}`}></div>
+              <div className={`flex-1 h-[2px] mx-2 ${index < currentStepIndex ? 'bg-primary' : 'bg-gray-300'}`}></div>
             )}
             {/* 마지막은 사이 선 만들 필요 없음 */}
           </div>

--- a/src/components/todaysmeal/steps/Step0Start.tsx
+++ b/src/components/todaysmeal/steps/Step0Start.tsx
@@ -17,7 +17,7 @@ const Step0Start = ({ onNext }: Step0StartProps) => {
         </h3>
       </div>
 
-      {/* TODO: 나중에 이미지를 배경으로 두던가해서 디자인 좀 전체적으로 개선 필요 */}
+      {/* TODO: 나중에 이미지를 배경으로 두거나나해서 디자인 좀 전체적으로 개선 필요 */}
 
       {/* 이미지 요소 */}
       <div className="flex justify-center mb-8">

--- a/src/components/todaysmeal/steps/Step1Goal.tsx
+++ b/src/components/todaysmeal/steps/Step1Goal.tsx
@@ -6,14 +6,15 @@ import PreviousButton from '../buttons/PreviousButton';
 import Option from '../options/Option';
 
 interface Step1GoalProps {
+  data?: string;
   onNext: (goal: string) => void;
   onPrev: () => void;
 }
 
-const Step1Goal = ({ onNext, onPrev }: Step1GoalProps) => {
+const Step1Goal = ({ onNext, onPrev, data }: Step1GoalProps) => {
   const goals = ['확실한 체중 감량', '적당한 체중 감량', '체중 유지', '적당한 체중 증량', '확실한 체중 증량'];
 
-  const [selectedGoal, setSelectedGoal] = useState<string | null>(null); // 선택 옵션 상태관리
+  const [selectedGoal, setSelectedGoal] = useState<string | null>(data ?? null); // 선택 옵션 상태관리
 
   const handleGoalSelect = (goal: string) => {
     setSelectedGoal(goal); // 선택한 목표 저장

--- a/src/components/todaysmeal/steps/Step2Meal.tsx
+++ b/src/components/todaysmeal/steps/Step2Meal.tsx
@@ -6,18 +6,19 @@ import PreviousButton from '../buttons/PreviousButton';
 import Option from '../options/Option';
 
 interface Step2MealProps {
+  data?: string[];
   onNext: (selectedMeals: string[]) => void;
   onPrev: () => void;
 }
 
-const Step2Meal = ({ onNext, onPrev }: Step2MealProps) => {
+const Step2Meal = ({ onNext, onPrev, data }: Step2MealProps) => {
   const meals = ['아침', '점심', '저녁'];
 
-  const [selectedMeals, setSelectedMeals] = useState<string[]>([]); // 복수 선택 상태관리
+  const [selectedMeals, setSelectedMeals] = useState<string[]>(data ?? []); // 복수 선택 상태관리
 
   const handleMealToggle = (meal: string) => {
     setSelectedMeals((prev) => (prev.includes(meal) ? prev.filter((m) => m !== meal) : [...prev, meal]));
-    // 선택한 게 이미 선택 리스트에 있으면 빼버리고, 없으면 추가가
+    // 선택한 게 이미 선택 리스트에 있으면 빼버리고, 없으면 추가
   };
 
   const handleNextClick = () => {

--- a/src/components/todaysmeal/steps/Step3HeightWeight.tsx
+++ b/src/components/todaysmeal/steps/Step3HeightWeight.tsx
@@ -6,6 +6,8 @@ import NextButton from '../buttons/NextButton';
 import PreviousButton from '../buttons/PreviousButton';
 
 interface Step3HeightWeightProps {
+  heightData?: number;
+  weightData?: number;
   onNext: (data: { height: number; weight: number }) => void;
   onPrev: () => void;
 }
@@ -15,13 +17,18 @@ type FormData = {
   weight: number;
 };
 
-const Step3HeightWeight = ({ onNext, onPrev }: Step3HeightWeightProps) => {
+const Step3HeightWeight = ({ onNext, onPrev, heightData, weightData }: Step3HeightWeightProps) => {
   const {
     register,
     handleSubmit,
     control,
     formState: { errors }
-  } = useForm<FormData>();
+  } = useForm<FormData>({
+    defaultValues: {
+      height: heightData || undefined, 
+      weight: weightData || undefined 
+    }
+  });
 
   const height = useWatch({ control, name: 'height' }); // height 값 감지
   const weight = useWatch({ control, name: 'weight' }); // weight 값 감지

--- a/src/components/todaysmeal/steps/Step4GenderAge.tsx
+++ b/src/components/todaysmeal/steps/Step4GenderAge.tsx
@@ -7,6 +7,8 @@ import PreviousButton from '../buttons/PreviousButton';
 import Option from '../options/Option';
 
 interface Step4GenderAgeProps {
+  genderData?: string;
+  ageData?: number;
   onNext: (data: { gender: string; age: number }) => void;
   onPrev: () => void;
 }
@@ -15,15 +17,19 @@ type FormData = {
   age: number;
 };
 
-const Step4GenderAge = ({ onNext, onPrev }: Step4GenderAgeProps) => {
-  const [gender, setGender] = React.useState<string | null>(null);
+const Step4GenderAge = ({ onNext, onPrev, genderData, ageData }: Step4GenderAgeProps) => {
+  const [gender, setGender] = React.useState<string | null>(genderData ?? null);
 
   const {
     register,
     handleSubmit,
     control,
     formState: { errors }
-  } = useForm<FormData>();
+  } = useForm<FormData>({
+    defaultValues: {
+      age: ageData || undefined
+    }
+  });
 
   const age = useWatch({ control, name: 'age' });
 
@@ -52,11 +58,11 @@ const Step4GenderAge = ({ onNext, onPrev }: Step4GenderAgeProps) => {
           <input
             type="number"
             placeholder="나이"
-            min={1}
+            min={10}
             max={130}
             {...register('age', {
               required: '나이를 입력해주세요.',
-              min: { value: 1, message: '나이는 1세 이상이어야 합니다.' },
+              min: { value: 10, message: '나이는 10세 이상이어야 합니다.' },
               max: { value: 130, message: '나이는 130세 이하여야 합니다.' }
             })}
             className="border-2 rounded-md px-4 py-3 text-center w-full border-primary"

--- a/src/components/todaysmeal/steps/Step5Activity.tsx
+++ b/src/components/todaysmeal/steps/Step5Activity.tsx
@@ -6,11 +6,12 @@ import PreviousButton from '../buttons/PreviousButton';
 import Option from '../options/Option';
 
 interface Step5ActivityProps {
+  activityData?: string;
   onNext: (activityLevel: string) => void;
   onPrev: () => void;
 }
 
-const Step5Activity = ({ onNext, onPrev }: Step5ActivityProps) => {
+const Step5Activity = ({ onNext, onPrev, activityData }: Step5ActivityProps) => {
   const activities = [
     '활동이 거의 없고, 운동을 하지 않는다',
     '가벼운 운동 (일주일 기준 1~3회 정도)',
@@ -19,7 +20,7 @@ const Step5Activity = ({ onNext, onPrev }: Step5ActivityProps) => {
     '운동선수 & 강도 높은 운동을 한다'
   ];
 
-  const [selectedActivity, setSelectedActivity] = useState<string | null>(null); //선택한 활동 옵션 상태 관리리
+  const [selectedActivity, setSelectedActivity] = useState<string | null>(activityData ?? null); //선택한 활동 옵션 상태 관리리
 
   const handleActivitySelect = (activity: string) => {
     setSelectedActivity(activity);

--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -4,7 +4,7 @@ import React, { useState, ReactNode } from 'react';
 // ReactNode: 렌더링 가능한 노드를 표현하는 타입 ===> children을 위한 타입을 위해 사용함.
 
 interface StepProps {
-  name: string; 
+  name: string; //일단 여기서 쓰이지는 않지만, MealPlanner에서 step 명시 목적으로 name 표시함.
   children: ReactNode; // 각 Step 컴포넌트가 렌더링할 자식 요소
 }
 


### PR DESCRIPTION
- contextAPI 사용 대신 props로 그냥 간단하게 정보 넘겨 받아서 초기값이 사용자가 이미 선택한 값으로 보여지게 하였습니다. 
- 이전 버튼 클릭으로 이전 step으로 넘어갈 시 사용자들은 다시 항목을 선택할 필요가 없고, 수정이 가능하게 UX를 개선했습니다.
- 앞으로 step6부분을 완성해야하고, step4 부분에 유효성 검사 관련 오류를 고쳐야할 필요가 있습니다.

